### PR TITLE
Wait for DOM ready before doing anything in the preload

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "electron-compile": "^6.4.0",
+    "electron-spellchecker": "^1.0.6",
     "runas": "^3.1.1"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -4,8 +4,8 @@ let mainWindow;
 
 const createWindow = () => {
   mainWindow = new BrowserWindow({
-    width: 800,
-    height: 600,
+    width: 560,
+    height: 680,
   });
 
   mainWindow.loadURL(`file://${__dirname}/webview.html`);

--- a/src/preload.js
+++ b/src/preload.js
@@ -1,8 +1,7 @@
-const { ipcRenderer } = require('electron');
-const { ContextMenuListener, SpellCheckHandler, setGlobalLogger } = require('electron-spellchecker');
-
+const SpellCheckHandler = require('electron-spellchecker').SpellCheckHandler;
 const spellchecker = new SpellCheckHandler();
 
 window.injectedGlobal = {
+  pid: process.pid,
   spellchecker
 };

--- a/src/preload.js
+++ b/src/preload.js
@@ -1,7 +1,10 @@
-const SpellCheckHandler = require('electron-spellchecker').SpellCheckHandler;
-const spellchecker = new SpellCheckHandler();
+window.setupGlobal = () => {
+  const SpellCheckHandler = require('electron-spellchecker').SpellCheckHandler;
+  const spellchecker = new SpellCheckHandler();
+  spellchecker.attachToInput();
 
-window.injectedGlobal = {
-  pid: process.pid,
-  spellchecker
+  window.injectedGlobal = {
+    pid: process.pid,
+    spellchecker
+  };
 };

--- a/src/preload.js
+++ b/src/preload.js
@@ -1,7 +1,8 @@
-const runas = require('runas');
+const { ipcRenderer } = require('electron');
+const { ContextMenuListener, SpellCheckHandler, setGlobalLogger } = require('electron-spellchecker');
+
+const spellchecker = new SpellCheckHandler();
 
 window.injectedGlobal = {
-  runas
+  spellchecker
 };
-
-document.addEventListener('DOMContentLoaded', () => console.log(process.pid));

--- a/src/webview.html
+++ b/src/webview.html
@@ -15,7 +15,7 @@
 
   webview.addEventListener('dom-ready', () => {
     webview.openDevTools();
-    webview.executeJavaScript('window.injectedGlobal.spellchecker.attachToInput()');
+    webview.executeJavaScript('window.setupGlobal()');
   });
 
   webview.addEventListener('load-commit', (e) => {

--- a/src/webview.html
+++ b/src/webview.html
@@ -10,7 +10,6 @@
 </body>
 
 <script>
-  const { ipcMain } = require('electron');
   const webview = document.querySelector('webview');
 
   webview.addEventListener('dom-ready', () => {

--- a/src/webview.html
+++ b/src/webview.html
@@ -10,10 +10,12 @@
 </body>
 
 <script>
+  const { ipcMain } = require('electron');
   const webview = document.querySelector('webview');
 
   webview.addEventListener('dom-ready', () => {
-    webview.openDevTools()
+    webview.openDevTools();
+    webview.executeJavaScript('window.injectedGlobal.spellchecker.attachToInput()');
   });
 
   webview.addEventListener('load-commit', (e) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1540,15 +1540,15 @@ electron-download@^3.0.1:
     semver "^5.3.0"
     sumchecker "^1.2.0"
 
-electron-prebuilt-compile@^1.6.2:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/electron-prebuilt-compile/-/electron-prebuilt-compile-1.6.2.tgz#22b8ab92718e24dd9d1c9cb21d371c727b172a9d"
+electron-prebuilt-compile@1.6.5:
+  version "1.6.5"
+  resolved "https://registry.yarnpkg.com/electron-prebuilt-compile/-/electron-prebuilt-compile-1.6.5.tgz#b86b120a14cdce9c0728e1a90b7ab5703b66b019"
   dependencies:
     babel-plugin-array-includes "^2.0.3"
     babel-plugin-transform-async-to-generator "^6.8.0"
     babel-preset-es2016-node5 "^1.1.2"
     babel-preset-react "^6.11.1"
-    electron "1.6.2"
+    electron "1.6.5"
     electron-compile "*"
     electron-compilers "*"
     yargs "^6.6.0"
@@ -1584,9 +1584,9 @@ electron-to-chromium@^1.2.7:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.8.tgz#b2c8a2c79bb89fbbfd3724d9555e15095b5f5fb6"
 
-electron@1.6.2:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-1.6.2.tgz#b0ccd7703f86d09c4d2a7273455c3f993f158994"
+electron@1.6.5:
+  version "1.6.5"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-1.6.5.tgz#6408d738025bc34f7c0ce8ee8827539475680a99"
   dependencies:
     electron-download "^3.0.1"
     extract-zip "^1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,15 @@
 # yarn lockfile v1
 
 
+"@paulcbetts/cld@^2.4.6":
+  version "2.4.6"
+  resolved "https://registry.yarnpkg.com/@paulcbetts/cld/-/cld-2.4.6.tgz#a992f6bc43cab212ac2c4488a671cf302f8b62e7"
+  dependencies:
+    glob "^5.0.10"
+    nan "^2.0.5"
+    rimraf "^2.4.0"
+    underscore "^1.6.0"
+
 "@paulcbetts/mime-db@~1.22.0":
   version "1.22.4"
   resolved "https://registry.yarnpkg.com/@paulcbetts/mime-db/-/mime-db-1.22.4.tgz#b8ff8e78087a40992990f702f8d9c65499be2ef1"
@@ -11,6 +20,12 @@
   resolved "https://registry.yarnpkg.com/@paulcbetts/mime-types/-/mime-types-2.1.10.tgz#8aa531f1f68fac80842e79aeff86797c309227dd"
   dependencies:
     "@paulcbetts/mime-db" "~1.22.0"
+
+"@paulcbetts/spellchecker@^4.0.5":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@paulcbetts/spellchecker/-/spellchecker-4.0.5.tgz#4ea9bfb85faba53c094c0809a18986bf44265c5f"
+  dependencies:
+    nan "^2.0.0"
 
 "@paulcbetts/vueify@9.4.3":
   version "9.4.3"
@@ -889,6 +904,10 @@ balanced-match@^0.4.1, balanced-match@^0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
 
+bcp47@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/bcp47/-/bcp47-1.1.2.tgz#354be3307ffd08433a78f5e1e2095845f89fc7fe"
+
 bcrypt-pbkdf@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz#63bc5dcb61331b92bc05fd528953c33462a06f8d"
@@ -1293,6 +1312,12 @@ d@1:
   dependencies:
     es5-ext "^0.10.9"
 
+d@~0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/d/-/d-0.1.1.tgz#da184c535d18d8ee7ba2aa229b914009fae11309"
+  dependencies:
+    es5-ext "~0.10.2"
+
 damerau-levenshtein@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz#03191c432cb6eea168bb77f3a55ffdccb8978514"
@@ -1307,7 +1332,7 @@ de-indent@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"
 
-debug@*, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.5.1:
+debug@*, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.5.1, debug@^2.6.3:
   version "2.6.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.4.tgz#7586a9b3c39741c0282ae33445c4e8ac74734fe0"
   dependencies:
@@ -1528,6 +1553,33 @@ electron-prebuilt-compile@^1.6.2:
     electron-compilers "*"
     yargs "^6.6.0"
 
+electron-remote@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/electron-remote/-/electron-remote-1.1.2.tgz#af71665ebd03ad0652ce0359c73990affbc933d9"
+  dependencies:
+    debug "^2.5.1"
+    hashids "^1.1.1"
+    pify "^2.3.0"
+    rxjs "^5.0.0-beta.12"
+    xmlhttprequest "^1.8.0"
+
+electron-spellchecker@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/electron-spellchecker/-/electron-spellchecker-1.0.6.tgz#2f0c548b60e08137f587a5e32e0961e4810f005b"
+  dependencies:
+    "@paulcbetts/cld" "^2.4.6"
+    "@paulcbetts/spellchecker" "^4.0.5"
+    bcp47 "^1.1.2"
+    debug "^2.6.3"
+    electron-remote "^1.1.1"
+    keyboard-layout "^2.0.7"
+    lru-cache "^4.0.2"
+    mkdirp "^0.5.1"
+    pify "^2.3.0"
+    rxjs "^5.0.1"
+    rxjs-serial-subscription "^0.1.1"
+    spawn-rx "^2.0.7"
+
 electron-to-chromium@^1.2.7:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.8.tgz#b2c8a2c79bb89fbbfd3724d9555e15095b5f5fb6"
@@ -1538,6 +1590,15 @@ electron@1.6.2:
   dependencies:
     electron-download "^3.0.1"
     extract-zip "^1.0.3"
+
+emissary@^1.2.0:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/emissary/-/emissary-1.3.3.tgz#a618d92d682b232d31111dc3625a5df661799606"
+  dependencies:
+    es6-weak-map "^0.1.2"
+    mixto "1.x"
+    property-accessors "^1.1"
+    underscore-plus "1.x"
 
 entities@1.0:
   version "1.0.0"
@@ -1576,7 +1637,7 @@ es-to-primitive@^1.1.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.1"
 
-es5-ext@^0.10.14, es5-ext@^0.10.9, es5-ext@~0.10.14:
+es5-ext@^0.10.14, es5-ext@^0.10.9, es5-ext@~0.10.14, es5-ext@~0.10.2, es5-ext@~0.10.5, es5-ext@~0.10.6:
   version "0.10.15"
   resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.15.tgz#c330a5934c1ee21284a7c081a86e5fd937c91ea6"
   dependencies:
@@ -1590,6 +1651,14 @@ es6-iterator@2, es6-iterator@^2.0.1, es6-iterator@~2.0.1:
     d "1"
     es5-ext "^0.10.14"
     es6-symbol "^3.1"
+
+es6-iterator@~0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-0.1.3.tgz#d6f58b8c4fc413c249b4baa19768f8e4d7c8944e"
+  dependencies:
+    d "~0.1.1"
+    es5-ext "~0.10.5"
+    es6-symbol "~2.0.1"
 
 es6-map@^0.1.3:
   version "0.1.5"
@@ -1622,6 +1691,22 @@ es6-symbol@3.1.1, es6-symbol@^3.1, es6-symbol@^3.1.1, es6-symbol@~3.1, es6-symbo
   dependencies:
     d "1"
     es5-ext "~0.10.14"
+
+es6-symbol@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-2.0.1.tgz#761b5c67cfd4f1d18afb234f691d678682cb3bf3"
+  dependencies:
+    d "~0.1.1"
+    es5-ext "~0.10.5"
+
+es6-weak-map@^0.1.2:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/es6-weak-map/-/es6-weak-map-0.1.4.tgz#706cef9e99aa236ba7766c239c8b9e286ea7d228"
+  dependencies:
+    d "~0.1.1"
+    es5-ext "~0.10.6"
+    es6-iterator "~0.1.3"
+    es6-symbol "~2.0.1"
 
 es6-weak-map@^2.0.1:
   version "2.0.2"
@@ -1805,6 +1890,12 @@ event-emitter@~0.3.5:
     d "1"
     es5-ext "~0.10.14"
 
+event-kit@^1.0.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/event-kit/-/event-kit-1.5.0.tgz#124ef6aad8328dcb26b71c47590b5b8e63ebc487"
+  dependencies:
+    grim "^1.2.1"
+
 exit-hook@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
@@ -1947,7 +2038,7 @@ glob@7.0.x:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^5.0.15:
+glob@^5.0.10, glob@^5.0.15:
   version "5.0.15"
   resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
   dependencies:
@@ -2007,6 +2098,12 @@ graphql@^0.9.3:
   dependencies:
     iterall "1.0.3"
 
+grim@^1.2.1:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/grim/-/grim-1.5.0.tgz#b32b08ef567cf1852f81759ed9c68b0d71396a32"
+  dependencies:
+    emissary "^1.2.0"
+
 handlebars@^4.0.1:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.6.tgz#2ce4484850537f9c97a8026d5399b935c4ed4ed7"
@@ -2047,6 +2144,10 @@ has@^1.0.1:
 hash-sum@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/hash-sum/-/hash-sum-1.0.2.tgz#33b40777754c6432573c120cc3808bbd10d47f04"
+
+hashids@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/hashids/-/hashids-1.1.1.tgz#3c36fcc5b3ba1a96a8fa67a632eb7877c41c6d3e"
 
 hawk@~3.1.3:
   version "3.1.3"
@@ -2457,6 +2558,13 @@ jsx-ast-utils@^1.0.0, jsx-ast-utils@^1.3.4:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz#3867213e8dd79bf1e8f2300c0cfc1efb182c0df1"
 
+keyboard-layout@^2.0.7:
+  version "2.0.12"
+  resolved "https://registry.yarnpkg.com/keyboard-layout/-/keyboard-layout-2.0.12.tgz#8729071046bd48cedee0c85f42fa746782f290a5"
+  dependencies:
+    event-kit "^1.0.0"
+    nan "^2.0.0"
+
 kind-of@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.1.0.tgz#475d698a5e49ff5e53d14e3e732429dc8bf4cf47"
@@ -2546,7 +2654,7 @@ loud-rejection@^1.0.0:
     currently-unhandled "^0.4.1"
     signal-exit "^3.0.0"
 
-lru-cache@^4.0.0, lru-cache@^4.0.1:
+lru-cache@^4.0.0, lru-cache@^4.0.1, lru-cache@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.0.2.tgz#1d17679c069cda5d040991a09dbc2c0db377e55e"
   dependencies:
@@ -2612,6 +2720,10 @@ minimist@^1.1.0, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
+mixto@1.x:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/mixto/-/mixto-1.0.0.tgz#c320ef61b52f2898f522e17d8bbc6d506d8425b6"
+
 mkdirp@0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.0.tgz#1d73076a6df986cd9344e15e71fcc05a4c9abf12"
@@ -2636,7 +2748,7 @@ mute-stream@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
 
-nan@2.x:
+nan@2.x, nan@^2.0.0, nan@^2.0.5:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.6.2.tgz#e4ff34e6c95fdfb5aecc08de6596f43605a7db45"
 
@@ -3123,6 +3235,13 @@ promise@~2.0:
   dependencies:
     is-promise "~1"
 
+property-accessors@^1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/property-accessors/-/property-accessors-1.1.3.tgz#1dde84024631865909ef30703365680c5f928b15"
+  dependencies:
+    es6-weak-map "^0.1.2"
+    mixto "1.x"
+
 prr@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/prr/-/prr-0.0.0.tgz#1a84b85908325501411853d0081ee3fa86e2926a"
@@ -3360,7 +3479,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@^2.2.8, rimraf@^2.5.4:
+rimraf@^2.2.8, rimraf@^2.4.0, rimraf@^2.5.4:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
   dependencies:
@@ -3382,7 +3501,13 @@ rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
 
-rxjs@^5.1.1:
+rxjs-serial-subscription@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/rxjs-serial-subscription/-/rxjs-serial-subscription-0.1.1.tgz#a42b1db0bf1094b09231191e2778ca3fcf9ed147"
+  dependencies:
+    rxjs "^5.0.0-beta.12"
+
+rxjs@^5.0.0-beta.12, rxjs@^5.0.1, rxjs@^5.1.1:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.3.0.tgz#d88ccbdd46af290cbdb97d5d8055e52453fabe2d"
   dependencies:
@@ -3492,7 +3617,7 @@ source-map@~0.2.0:
   dependencies:
     amdefine ">=0.0.4"
 
-spawn-rx@^2.0.3:
+spawn-rx@^2.0.3, spawn-rx@^2.0.7:
   version "2.0.10"
   resolved "https://registry.yarnpkg.com/spawn-rx/-/spawn-rx-2.0.10.tgz#a8cb098f4bb5de51dad06851b7018549230ef9d5"
   dependencies:
@@ -3777,6 +3902,16 @@ uglify-to-browserify@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
 
+underscore-plus@1.x:
+  version "1.6.6"
+  resolved "https://registry.yarnpkg.com/underscore-plus/-/underscore-plus-1.6.6.tgz#65ecde1bdc441a35d89e650fd70dcf13ae439a7d"
+  dependencies:
+    underscore "~1.6.0"
+
+underscore@^1.6.0, underscore@~1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.6.0.tgz#8b38b10cacdef63337b8b24e4ff86d45aea529a8"
+
 uniq@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff"
@@ -3912,6 +4047,10 @@ write@^0.2.1:
 "xml-name-validator@>= 2.0.1 < 3.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
+
+xmlhttprequest@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz#67fe075c5c24fef39f9d65f5f7b7fe75171968fc"
 
 xtend@^4.0.0:
   version "4.0.1"


### PR DESCRIPTION
This demonstrates a possible fix for https://github.com/electron/electron/issues/4025; if we wait til the `dom-ready` event before doing anything in the preload script, we dodge the native module issue completely. This makes me think that the preload script _itself_ should not run until we're in the page context; perhaps in the normal case it's running while the process is in some halfway state?